### PR TITLE
changed python version from 3.9 to 3.13

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -84,7 +84,7 @@ resource "azurerm_linux_function_app" "fa_auxo_provider_azure" {
         application_insights_key               = azurerm_application_insights.ai_auxo_provider_azure.instrumentation_key
         application_insights_connection_string = azurerm_application_insights.ai_auxo_provider_azure.connection_string
         application_stack {
-            python_version = "3.9"
+            python_version = "3.13"
         }
     }
 


### PR DESCRIPTION
Python 3.9 support is EoL at Microsoft per 31 October 2025