### PR TITLE
Update host.json

### DIFF
--- a/host.json
+++ b/host.json
@@ -10,6 +10,6 @@
   },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[3.*, 4.0.0)"
+    "version": "[4.*, 5.0.0)"
   }
 }


### PR DESCRIPTION
# Microsoft Announcement

Extension bundles v1, v2, and v3 are deprecated 

## Details

Per the Azure Functions extension bundles support policy, the most recent major version is considered the active version and is the only recommended version for your function apps. Older versions (v1, v2, and v3) are deprecated and no longer supported. Function apps that continue to use a deprecated bundle can still run on the platform. However, to ensure access to new features, performance improvements, security patches, and full support, you must upgrade your function apps to a supported bundle version.

## Required Action

Upgrade your Functions apps to extension bundle v4, the latest active version. To stay secure and always benefit from the latest minor updates, we recommend referencing v4 as a range, [4.*, 5.0.0), in host.json.